### PR TITLE
chore: bump version to 0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gsobench"
-version = "0.1.2"
+version = "0.1.3"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -644,7 +644,7 @@ wheels = [
 
 [[package]]
 name = "gsobench"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "black" },


### PR DESCRIPTION
### Motivation
- Prepare a new release by updating the package version to `0.1.3`.

### Description
- Updated `pyproject.toml` package `version` to `0.1.3` and synchronized `uv.lock` metadata for the `gsobench` package to `0.1.3`.

### Testing
- No automated tests were run for this PR because it is a version bump only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696717a31278832d863c9a43eccbf091)