### PR TITLE
fix: remove hidden test scripts from Docker images

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gsobench"
-version = "0.1.2"
+version = "0.1.3"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/gso/analysis/quantitative/plot_opt1_threshold.py
+++ b/src/gso/analysis/quantitative/plot_opt1_threshold.py
@@ -15,6 +15,9 @@ from gso.constants import PLOTS_DIR, EVALUATION_REPORTS_DIR, MIN_PROB_SPEEDUP
 # =============================================================================
 
 MODEL_CONFIGS = {
+    "Gemini-3-Flash": "/home/gcpuser/gso-internal/logs/run_evaluation/pass/gemini-3-flash-preview_maxiter_100_N_v0.51.1-no-hint-run_*",
+    "GPT-5.1": "/home/gcpuser/gso-internal/logs/run_evaluation/pass/gpt-5.1-2025-11-13_maxiter_100_N_v0.51.1-no-hint-run_*",
+    "GPT-5.2": "/home/gcpuser/gso-internal/logs/run_evaluation/pass/gpt-5.2-2025-12-11_maxiter_100_N_v0.51.1-no-hint-run_*",
     "Opus-4.5": "/home/gcpuser/gso-internal/logs/run_evaluation/pass/claude-opus-4-5-20251101_maxiter_100_N_v0.51.1-no-hint-run_*",
     "Gemini-3-Pro": "/home/gcpuser/gso-internal/logs/run_evaluation/pass/gemini-3-pro-preview_maxiter_100_N_v0.51.1-no-hint-run_*",
     "Sonnet-4.5": "/home/gcpuser/gso-internal/logs/run_evaluation/pass/claude-sonnet-4-5-20250929_maxiter_100_N_v0.51.1-no-hint-run_*",

--- a/src/gso/harness/environment/dockerfile.py
+++ b/src/gso/harness/environment/dockerfile.py
@@ -80,6 +80,10 @@ RUN find / -maxdepth 1 -name 'gso_test_*.py' -exec bash -c "source .venv/bin/act
 
 # Automatically activate the env within the testbed directory
 RUN echo "source .venv/bin/activate" >> /root/.bashrc
+
+# Remove test scripts after pre-caching to prevent agent access
+# Tests will be injected at evaluation time
+RUN rm -f /gso_test*.py
 """
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -644,7 +644,7 @@ wheels = [
 
 [[package]]
 name = "gsobench"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "black" },


### PR DESCRIPTION
## Summary

Agents should only have access to `prob_script`, not the hidden test scripts used for evaluation. This change ensures test scripts are not accessible in Docker images.

**Changes:**
- Remove test scripts from Docker images after pre-caching (tests are still used during build to warm up HuggingFace caches)
- Inject test scripts at evaluation time in `grade.py` (with patches applied, same as during image build)
- Bump version to 0.1.3

## Test plan

- [x] Verified new image has no test files in `/` (old image had 20 test files)
- [x] Rebuilt all 102 images and pushed to DockerHub
- [x] Run evaluation to verify tests are properly injected at eval time
- [x] Verify eval w/ a sample few gso instances + gt patch

Fixes: https://github.com/gso-bench/gso/issues/18

---
🤖 Generated with [Claude Code](https://claude.ai/code)