### PR TITLE
fix: setuptools 82+ and HF Hub Xet compatibility

### DIFF
--- a/src/gso/data/dataset.py
+++ b/src/gso/data/dataset.py
@@ -39,6 +39,14 @@ class GSOInstance:
     def install_repo_script(self):
         env_name = "testbed"
         repo_directory = f"/{env_name}"
+
+        # Pin setuptools<82 in build isolation to preserve pkg_resources
+        # for legacy setup.py projects (setuptools 82+ removed pkg_resources)
+        build_constraint_setup = [
+            "echo 'setuptools<82' > /tmp/uv_build_constraints.txt",
+            "export UV_BUILD_CONSTRAINT=/tmp/uv_build_constraints.txt",
+        ]
+
         repo_setup = [
             f"git clone -o origin {self.repo_url} {repo_directory}",
             f"chmod -R 777 {repo_directory}",  # nonroot user can run tests
@@ -51,6 +59,7 @@ class GSOInstance:
         return (
             "\n".join(
                 ["#!/bin/bash", "set -euxo pipefail"]
+                + build_constraint_setup
                 + repo_setup
                 + self.install_commands
             )

--- a/src/gso/harness/environment/dockerfile.py
+++ b/src/gso/harness/environment/dockerfile.py
@@ -75,8 +75,9 @@ COPY ./gso_test*.py /
 WORKDIR /testbed/
 
 # Run setup for all test and check if cache is full
-RUN find / -maxdepth 1 -name 'gso_test_*.py' -exec bash -c "source .venv/bin/activate && export HF_TOKEN={hf_token} && cd / && python {{}} prep.txt --reference --file_prefix prep" \;
-RUN find / -maxdepth 1 -name 'gso_test_*.py' -exec bash -c "source .venv/bin/activate && export DEBUG_GSO="true" && export HF_TOKEN={hf_token} && cd / && python {{}} prep.txt --reference --file_prefix prep" \;
+# HF_HUB_DISABLE_XET=1 avoids Xet storage backend issues during pre-caching
+RUN find / -maxdepth 1 -name 'gso_test_*.py' -exec bash -c "source .venv/bin/activate && export HF_TOKEN={hf_token} && export HF_HUB_DISABLE_XET=1 && cd / && python {{}} prep.txt --reference --file_prefix prep" \;
+RUN find / -maxdepth 1 -name 'gso_test_*.py' -exec bash -c "source .venv/bin/activate && export DEBUG_GSO="true" && export HF_TOKEN={hf_token} && export HF_HUB_DISABLE_XET=1 && cd / && python {{}} prep.txt --reference --file_prefix prep" \;
 
 # Automatically activate the env within the testbed directory
 RUN echo "source .venv/bin/activate" >> /root/.bashrc

--- a/src/gso/harness/grading/evalscript.py
+++ b/src/gso/harness/grading/evalscript.py
@@ -211,11 +211,21 @@ def get_eval_script(instance) -> str:
         f'echo "{END_COMMIT_OUTPUT}"',
     ]
 
+    # Pin setuptools<82 in build isolation to preserve pkg_resources
+    # for legacy setup.py projects (setuptools 82+ removed pkg_resources)
+    # Disable HF Hub Xet backend to avoid server-side header issues
+    env_setup = "\n".join([
+        "echo 'setuptools<82' > /tmp/uv_build_constraints.txt",
+        "export UV_BUILD_CONSTRAINT=/tmp/uv_build_constraints.txt",
+        "export HF_HUB_DISABLE_XET=1",
+    ])
+
     return (
         "\n".join(
             [
                 "#!/bin/bash",
                 "set -euo pipefail",  # add x for debugging
+                env_setup,
                 APPLY_PATCH_HELPER.format(
                     failed=APPLY_PATCH_FAIL, passed=APPLY_PATCH_PASS
                 ),


### PR DESCRIPTION
## Summary

Fixes two environment issues that cause evaluation failures on recent systems:

1. **setuptools 82+ removed `pkg_resources`** (released Feb 8, 2026): Legacy `setup.py` projects (e.g. older pandas) fail during `uv pip install . --reinstall` because PEP 517 build isolation pulls the latest setuptools, which no longer includes `pkg_resources`. Fixed by setting `UV_BUILD_CONSTRAINT` to pin `setuptools<82` in both the eval harness and Docker image build scripts.

2. **HuggingFace Hub Xet storage backend errors**: `huggingface_hub`'s Xet backend fails with `ValueError: Xet headers have not been correctly set by the server`, causing dataset downloads to fail during Docker image pre-caching and at evaluation runtime. Fixed by setting `HF_HUB_DISABLE_XET=1` to fall back to standard HTTPS downloads.

## Changes

- `evalscript.py`: Export `UV_BUILD_CONSTRAINT` and `HF_HUB_DISABLE_XET=1` at the top of generated eval scripts
- `dataset.py`: Export `UV_BUILD_CONSTRAINT` in `install_repo_script` for Docker image builds
- `dockerfile.py`: Add `HF_HUB_DISABLE_XET=1` to pre-caching RUN steps

## Impact

Tested on the full GSO benchmark (102 instances):
- Recovered 19 pandas instances from `test_failed` (pkg_resources fix)
- Recovered 1 tokenizers instance from `base_failed` (Xet fix)
- Rebuilt and pushed fixed Docker images for `huggingface__tokenizers-bfd9cde` and `huggingface__datasets-c5464b3`

Made with [Cursor](https://cursor.com)