### PR TITLE
fix: prevent HF token leakage in docker flow and bump version to 0.1.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gsobench"
-version = "0.1.5"
+version = "0.1.6"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/gso/harness/environment/docker_build.py
+++ b/src/gso/harness/environment/docker_build.py
@@ -5,6 +5,7 @@ import docker
 import docker.errors
 import logging
 import traceback
+import os
 from datetime import timedelta
 from dataclasses import dataclass
 from pathlib import Path
@@ -61,12 +62,11 @@ def build_image(
 
     ansi_escape = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
     start_time = time.time()
-    client = docker.from_env()
     logger = setup_logger(image_name, build_dir / "build_image.log")
 
     logger.info(
         f"Building image {image_name}\n"
-        f"Using dockerfile:\n{dockerfile}\n"
+        "Using dockerfile template (contents omitted to avoid secret leakage in logs)\n"
         f"Adding ({len(setup_scripts)}) setup scripts to image build repo"
     )
 
@@ -87,33 +87,46 @@ def build_image(
         with open(dockerfile_path, "w") as f:
             f.write(dockerfile)
 
-        # Build the image
+        # Build the image with BuildKit secret so token never appears in layers/history
         print(f"Building {image_name} in {build_dir} with platform {platform}")
         logger.info(f"Building {image_name} in {build_dir} with platform {platform}")
 
-        response = client.api.build(
-            path=str(build_dir),
-            tag=image_name,
-            rm=True,
-            forcerm=True,
-            decode=True,
-            platform=platform,
-            nocache=nocache,
-        )
+        env = os.environ.copy()
+        env["DOCKER_BUILDKIT"] = "1"
+        cmd = [
+            "docker",
+            "buildx",
+            "build",
+            "--load",
+            "--platform",
+            platform,
+            "--tag",
+            image_name,
+            "--file",
+            str(dockerfile_path),
+            "--secret",
+            "id=hf_read_token,env=HF_READ_TOKEN",
+        ]
+        if nocache:
+            cmd.append("--no-cache")
+        cmd.append(str(build_dir))
 
-        buildlog = ""
-        for chunk in response:
-            if "stream" in chunk:
-                chunk_stream = ansi_escape.sub("", chunk["stream"])
-                logger.info(chunk_stream.strip())
-                buildlog += chunk_stream
-            elif "errorDetail" in chunk:
-                logger.error(
-                    f"Error: {ansi_escape.sub('', chunk['errorDetail']['message'])}"
-                )
-                raise docker.errors.BuildError(
-                    chunk["errorDetail"]["message"], buildlog
-                )
+        process = subprocess.run(
+            cmd,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            env=env,
+        )
+        output = ansi_escape.sub("", process.stdout or "")
+        if output:
+            logger.info(output.strip())
+
+        if process.returncode != 0:
+            raise RuntimeError(
+                f"docker buildx failed for {image_name} with code {process.returncode}"
+            )
         logger.info("Image built successfully!")
     except subprocess.CalledProcessError as e:
         logger.error(f"Subprocess error during {image_name} build: {e}")
@@ -309,11 +322,11 @@ def create_container(
         # Create the container
         logger.info(f"Creating container for {instance.instance_id}...")
 
-        # Define arguments for running the container
+        # Inject HF token at runtime only (never into image layers/scripts).
+        runtime_hf_token = os.getenv("HF_READ_TOKEN") or os.getenv("HF_TOKEN")
         run_args = {}
         cap_add = run_args.get("cap_add", [])
-
-        container = client.containers.create(
+        container_kwargs = dict(
             image=instance.instance_image_key,
             name=instance.get_instance_container_name(run_id),
             user="root",
@@ -322,6 +335,10 @@ def create_container(
             platform=instance.platform,
             cap_add=cap_add,
         )
+        if runtime_hf_token:
+            container_kwargs["environment"] = {"HF_TOKEN": runtime_hf_token}
+
+        container = client.containers.create(**container_kwargs)
         logger.info(f"Container for {instance.instance_id} created: {container.id}")
         return container
     except Exception as e:

--- a/src/gso/harness/environment/dockerfile.py
+++ b/src/gso/harness/environment/dockerfile.py
@@ -1,4 +1,5 @@
 DOCKERFILE = r"""
+# syntax=docker/dockerfile:1.4
 FROM --platform={platform} ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -76,8 +77,9 @@ WORKDIR /testbed/
 
 # Run setup for all test and check if cache is full
 # HF_HUB_DISABLE_XET=1 avoids Xet storage backend issues during pre-caching
-RUN find / -maxdepth 1 -name 'gso_test_*.py' -exec bash -c "source .venv/bin/activate && export HF_TOKEN={hf_token} && export HF_HUB_DISABLE_XET=1 && cd / && python {{}} prep.txt --reference --file_prefix prep" \;
-RUN find / -maxdepth 1 -name 'gso_test_*.py' -exec bash -c "source .venv/bin/activate && export DEBUG_GSO="true" && export HF_TOKEN={hf_token} && export HF_HUB_DISABLE_XET=1 && cd / && python {{}} prep.txt --reference --file_prefix prep" \;
+# HF token is read from a BuildKit secret at build time only and never persisted.
+RUN --mount=type=secret,id=hf_read_token bash -lc 'set -euo pipefail; HF_TOKEN="$(cat /run/secrets/hf_read_token)"; export HF_TOKEN HF_HUB_DISABLE_XET=1; find / -maxdepth 1 -name "gso_test_*.py" -exec bash -c "source .venv/bin/activate && cd / && python {{}} prep.txt --reference --file_prefix prep" \;'
+RUN --mount=type=secret,id=hf_read_token bash -lc 'set -euo pipefail; HF_TOKEN="$(cat /run/secrets/hf_read_token)"; export DEBUG_GSO=true HF_TOKEN HF_HUB_DISABLE_XET=1; find / -maxdepth 1 -name "gso_test_*.py" -exec bash -c "source .venv/bin/activate && cd / && python {{}} prep.txt --reference --file_prefix prep" \;'
 
 # Automatically activate the env within the testbed directory
 RUN echo "source .venv/bin/activate" >> /root/.bashrc
@@ -101,9 +103,5 @@ def get_dockerfile_instance(platform: str, arch: str) -> str:
         raise ValueError(
             "A huggingface token w/ read access is needed for GSO dockers. Please set HF_READ_TOKEN."
         )
-    else:
-        hf_token = os.getenv("HF_READ_TOKEN")
 
-    return DOCKERFILE.format(
-        platform=platform, conda_arch=conda_arch, hf_token=hf_token
-    )
+    return DOCKERFILE.format(platform=platform, conda_arch=conda_arch)

--- a/src/gso/harness/grading/evalscript.py
+++ b/src/gso/harness/grading/evalscript.py
@@ -159,9 +159,10 @@ def get_eval_script(instance) -> str:
 
     run_base = "\n".join([RUN_BASE.format(i=i) for i in range(test_count)])
 
-    # Set tokens
+    # Do not bake token literals into eval.sh; rely on container runtime env injection.
     setup_tokens = [
-        f"export HF_TOKEN={os.getenv('HF_TOKEN')}" if os.getenv("HF_TOKEN") else "",
+        'if [ -n "${HF_TOKEN:-}" ]; then export HF_TOKEN; '
+        'elif [ -n "${HF_READ_TOKEN:-}" ]; then export HF_TOKEN="${HF_READ_TOKEN}"; fi'
     ]
 
     eval_commands = [

--- a/uv.lock
+++ b/uv.lock
@@ -644,7 +644,7 @@ wheels = [
 
 [[package]]
 name = "gsobench"
-version = "0.1.4"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "black" },


### PR DESCRIPTION
Use BuildKit secrets and runtime token injection so read tokens are never baked into image history or eval scripts, and cut a new patch release for the security fix.